### PR TITLE
Use "svn export" insted of "svn checkout"

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const newAry = head.concat(branch, tail);
 const svnURL = new url.URL(newAry.join('/'), 'https://github.com/').toString();
 
 console.log(`Downloading ${svnURL}...`);
-exec(`svn checkout ${svnURL}`, (err, stdout) => {
+exec(`svn export ${svnURL}`, (err, stdout) => {
 	if (err) throw err;
 
 	console.log(stdout);


### PR DESCRIPTION
Once we use svn as the download engine, we can use "svn export" instead. This way we avoid that the ".svn" folder gets created.